### PR TITLE
[fix] allow us to use expected word in tests

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -1,4 +1,4 @@
-# Workflow derived from https://github.com/r-lib/actions/tree/master/examples
+# Workflow derived from https://github.com/r-lib/actions/tree/v2/examples
 # Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
 on:
   push:
@@ -18,7 +18,7 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - {os: macOS-latest,   r: 'release'}
+          - {os: macos-latest,   r: 'release'}
           - {os: windows-latest, r: 'release'}
           - {os: ubuntu-latest,   r: 'devel', http-user-agent: 'release'}
           - {os: ubuntu-latest,   r: 'release'}
@@ -29,18 +29,21 @@ jobs:
       R_KEEP_PKG_SOURCE: yes
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
-      - uses: r-lib/actions/setup-pandoc@v1
+      - uses: r-lib/actions/setup-pandoc@v2
 
-      - uses: r-lib/actions/setup-r@v1
+      - uses: r-lib/actions/setup-r@v2
         with:
           r-version: ${{ matrix.config.r }}
           http-user-agent: ${{ matrix.config.http-user-agent }}
           use-public-rspm: true
 
-      - uses: r-lib/actions/setup-r-dependencies@v1
+      - uses: r-lib/actions/setup-r-dependencies@v2
         with:
-          extra-packages: rcmdcheck
+          extra-packages: any::rcmdcheck
+          needs: check
 
-      - uses: r-lib/actions/check-r-package@v1
+      - uses: r-lib/actions/check-r-package@v2
+        with:
+          upload-snapshots: true

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: testdown
 Title: 'testhat' Results to Bookdown
-Version: 0.1.2
+Version: 0.1.2.9000
 Authors@R: c(
     person("Colin", "Fay", , "contact@colinfay.me", role = c("cre", "aut"),
            comment = c(ORCID = "0000-0001-7343-1846")),
@@ -38,4 +38,4 @@ Suggests:
     yaml
 Encoding: UTF-8
 LazyData: true
-RoxygenNote: 7.1.2
+RoxygenNote: 7.2.3

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# testdown 0.1.2.9000
+
+* Change the regexp to fin "expect"
+
 # testdown 0.1.2
 
 * Update tests

--- a/R/tomarkdown.R
+++ b/R/tomarkdown.R
@@ -118,7 +118,7 @@ test_down <- function(
   all_tests_read <- all_tests_read %>%
     purrr::imap(~{
       names(.x) <- paste0(normalizePath(.y), "#", 1:length(.x))
-      res <- grep("expect_*", .x, value = TRUE)
+      res <- grep("expect\\_", .x, value = TRUE)
       gsub("^ +(.*)", "\\1", res)
     }) %>%
     unname() %>%

--- a/README.Rmd
+++ b/README.Rmd
@@ -23,8 +23,7 @@ file.copy(list.files("reference/figures", full.names = TRUE),
 
 <!-- badges: start -->
 [![Lifecycle: maturing](https://img.shields.io/badge/lifecycle-maturing-blue.svg)](https://www.tidyverse.org/lifecycle/#maturing)
-[![R build status](https://github.com/ThinkR-open/testdown/workflows/R-CMD-check/badge.svg)](https://github.com/ThinkR-open/testdown/actions)
-[![R-CMD-check](https://github.com/ThinkR-open/testdown/workflows/R-CMD-check/badge.svg)](https://github.com/ThinkR-open/testdown/actions)
+[![R-CMD-check](https://github.com/ThinkR-open/testdown/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/ThinkR-open/testdown/actions/workflows/R-CMD-check.yaml)
 <!-- badges: end -->
 
 The goal of `{testdown}` is to generate a bookdown report of `{testthat}` results

--- a/README.md
+++ b/README.md
@@ -7,8 +7,7 @@
 
 [![Lifecycle:
 maturing](https://img.shields.io/badge/lifecycle-maturing-blue.svg)](https://www.tidyverse.org/lifecycle/#maturing)
-[![R build
-status](https://github.com/ThinkR-open/testdown/workflows/R-CMD-check/badge.svg)](https://github.com/ThinkR-open/testdown/actions)
+[![R-CMD-check](https://github.com/ThinkR-open/testdown/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/ThinkR-open/testdown/actions/workflows/R-CMD-check.yaml)
 <!-- badges: end -->
 
 The goal of `{testdown}` is to generate a bookdown report of
@@ -18,7 +17,7 @@ The goal of `{testdown}` is to generate a bookdown report of
 
 You can install the dev version of `{testdown}`
 
--   from r-universe
+- from r-universe
 
 ``` r
 # Enable universe(s) by thinkr-open
@@ -30,7 +29,7 @@ options(repos = c(
 install.packages('testdown')
 ```
 
--   from GitHub with:
+- from GitHub with:
 
 ``` r
 remotes::install_github("ThinkR-open/testdown")
@@ -45,20 +44,20 @@ This package has two exported functions:
 This function turns the `{testthat}` results into a `{bookdown}` report.
 It takes:
 
--   A `project_name`, which is the name you want to give to the project.
-    The default is `NULL`, which will then be converted to
-    `basename(here::here())`.
--   An `author`, if you want your report to be have an author name.
-    Default is NULL, and then the report won’t have any name on it.
--   `pkg`, the path to the package that will be documented. Default is
-    `here::here()`
--   `environment`, a name for the testing environment. Default is
-    `here::here()`
--   `book_path`, the folder where you want the `{bookdown}` report to be
-    created. Default is `"tests/testdown"`.
--   `with_help` Should the help appendix be added? Default is `TRUE`.
--   `open` Should the report be opened once compiled? Default is
-    `interactive()`.
+- A `project_name`, which is the name you want to give to the project.
+  The default is `NULL`, which will then be converted to
+  `basename(here::here())`.
+- An `author`, if you want your report to be have an author name.
+  Default is NULL, and then the report won’t have any name on it.
+- `pkg`, the path to the package that will be documented. Default is
+  `here::here()`
+- `environment`, a name for the testing environment. Default is
+  `here::here()`
+- `book_path`, the folder where you want the `{bookdown}` report to be
+  created. Default is `"tests/testdown"`.
+- `with_help` Should the help appendix be added? Default is `TRUE`.
+- `open` Should the report be opened once compiled? Default is
+  `interactive()`.
 
 ### `test_down_example()`
 
@@ -98,71 +97,69 @@ test_that("hello_world() works", {
 
 There are three scopes when it comes to tests:
 
--   “Test files”, which are the files included inside the
-    `test/testthat/` folder, and which contain a testing infrastructure.
-    Each file contains one ore more test(s).
+- “Test files”, which are the files included inside the `test/testthat/`
+  folder, and which contain a testing infrastructure. Each file contains
+  one ore more test(s).
 
--   “Tests”, which start with `test_that("",`. Each test contains one or
-    more expectation(s).
+- “Tests”, which start with `test_that("",`. Each test contains one or
+  more expectation(s).
 
--   “Expectations”, which (usually) start with `expect_` (note that
-    `skip_` functions are also considered as expectations). An
-    expectation only contains one statement. If you put a roxygen tag
-    `@description` **just before your expectation**, it will be
-    displayed in the testing results (otherwise the ‘Description’ column
-    will be blank).
+- “Expectations”, which (usually) start with `expect_` (note that
+  `skip_` functions are also considered as expectations). An expectation
+  only contains one statement. If you put a roxygen tag `@description`
+  **just before your expectation**, it will be displayed in the testing
+  results (otherwise the ‘Description’ column will be blank).
 
 To sum up, Test files contains one or more test(s), which contain one or
 more expectation(s).
 
 #### Expectations status
 
--   ✅ <font color='green'>Success</font>: Passed (the expectation is
-    met).
+- ✅ <font color='green'>Success</font>: Passed (the expectation is
+  met).
 
--   ❌ <font color='red'>Failure</font>: Failed (the expectation is not
-    met).
+- ❌ <font color='red'>Failure</font>: Failed (the expectation is not
+  met).
 
--   ⚠️ <font color='orange'>Warning</font>: The expectation returned a
-    warning.
+- ⚠️ <font color='orange'>Warning</font>: The expectation returned a
+  warning.
 
--   ❌ <font color='red'>Error (test stopped)</font>: the expectation
-    has returned an error, and the current test was stopped (i.e further
-    expectations in the current test will not be launched).
+- ❌ <font color='red'>Error (test stopped)</font>: the expectation has
+  returned an error, and the current test was stopped (i.e further
+  expectations in the current test will not be launched).
 
--   🔄 <font color='blue'>Skip</font>: This expectation has validated a
-    “skip” expectation for the current test.
+- 🔄 <font color='blue'>Skip</font>: This expectation has validated a
+  “skip” expectation for the current test.
 
--   🔄 <font color='blue'>Was Skipped</font>: The expectation has been
-    skipped and is reported as a ‘skipped expectation’, due to a
-    `skip_if` or an error previously in the test. Note that when an
-    expectation is skipped, the Description, and Test time are not
-    retrieved.
+- 🔄 <font color='blue'>Was Skipped</font>: The expectation has been
+  skipped and is reported as a ‘skipped expectation’, due to a `skip_if`
+  or an error previously in the test. Note that when an expectation is
+  skipped, the Description, and Test time are not retrieved.
 
 ### First page
 
 The index offers a summary of:
 
--   When the tests were run
+- When the tests were run
 
--   The package (Title, Version, and Description of the package)
+- The package (Title, Version, and Description of the package)
 
--   The project
+- The project
 
-    -   Name of the project
-    -   Environment the tests were run into (aka the directory)
-    -   Details about the test results
+  - Name of the project
+  - Environment the tests were run into (aka the directory)
+  - Details about the test results
 
--   Results overview
+- Results overview
 
--   The testing infrastructure
+- The testing infrastructure
 
-    -   R version
-    -   Operating system
-    -   Locale
-    -   Package versions
+  - R version
+  - Operating system
+  - Locale
+  - Package versions
 
--   Glossary of terms
+- Glossary of terms
 
 ### Global results
 
@@ -170,17 +167,17 @@ This page offers a summary of the results, grouped by test.
 
 Details of the table:
 
--   File: Name of the file that contains the test. This column is
-    clickable and will open the corresponding page.
+- File: Name of the file that contains the test. This column is
+  clickable and will open the corresponding page.
 
--   Test: Label given to the test.
+- Test: Label given to the test.
 
--   Expectations: Number of expectations contained in the test.
+- Expectations: Number of expectations contained in the test.
 
--   Result: If the test contains one or more error(s), failed
-    expectation(s), or warning(s) ❌, otherwise ✅.
+- Result: If the test contains one or more error(s), failed
+  expectation(s), or warning(s) ❌, otherwise ✅.
 
--   Time spent: Time spent on this particular test.
+- Time spent: Time spent on this particular test.
 
 ### Test-files.R
 
@@ -192,46 +189,45 @@ test file.
 
 Then, details are included about the tested file:
 
--   Test: Label of the test (i.e. the text in
-    `test_that("label of the test", ...)`)
+- Test: Label of the test (i.e. the text in
+  `test_that("label of the test", ...)`)
 
--   Description: The description of the test, as detailed in the
-    `#' @description` roxygen tag used just before the expectation. If
-    no description was set, it will be blank.
+- Description: The description of the test, as detailed in the
+  `#' @description` roxygen tag used just before the expectation. If no
+  description was set, it will be blank.
 
--   Expectation: Raw name of the expectation, *i.e* the R code used.
+- Expectation: Raw name of the expectation, *i.e* the R code used.
 
--   Result: Success / Failure / Warning / Errored / Skip / Was skipped
-    (see “Expectations status” at the top of this page).
+- Result: Success / Failure / Warning / Errored / Skip / Was skipped
+  (see “Expectations status” at the top of this page).
 
--   Location: Name of the file containing the test, with the line number
-    where the expectation is located (for example,
-    `test-hello-world.R#9` means the expectation started at line 9, in
-    the `test-hello-world.R` file)
+- Location: Name of the file containing the test, with the line number
+  where the expectation is located (for example, `test-hello-world.R#9`
+  means the expectation started at line 9, in the `test-hello-world.R`
+  file)
 
--   Test_time: When was the test run.
+- Test_time: When was the test run.
 
 ### Aggregated
 
 Aggregation of expectations that returned a failure/error, warning, or
 were skipped.
 
--   Location: Name of the file containing the test, with the line number
-    where the expectation is located (for example,
-    `test-hello-world.R#9` means the expectation started at line 9, in
-    the `test-hello-world.R` file)
+- Location: Name of the file containing the test, with the line number
+  where the expectation is located (for example, `test-hello-world.R#9`
+  means the expectation started at line 9, in the `test-hello-world.R`
+  file)
 
--   Test: Label of the test (i.e. the text in
-    `test_that("label of the test", ...)`)
+- Test: Label of the test (i.e. the text in
+  `test_that("label of the test", ...)`)
 
--   Description: The description of the test, as detailed in the
-    `#' @description` roxygen tag used just before the expectation. If
-    no description was set, it will be blank.
+- Description: The description of the test, as detailed in the
+  `#' @description` roxygen tag used just before the expectation. If no
+  description was set, it will be blank.
 
--   Expectation: Raw name of the expectation, *i.e* the R code used.
+- Expectation: Raw name of the expectation, *i.e* the R code used.
 
--   Message: Message output by R when the expectation
-    failed/warned/skip.
+- Message: Message output by R when the expectation failed/warned/skip.
 
 ## Writing custom expectation
 
@@ -249,7 +245,7 @@ these outputs.
 Here are known example of results that will be discarded by `{testthat}`
 and hence will make `{testdown}` behave in a weird way.
 
--   Using `{withr}`
+- Using `{withr}`
 
 ``` r
 test_that("Files exist", {
@@ -271,7 +267,7 @@ As testthat doesn’t count the expectations from `with_dir`, this will
 make the `{testdown}` result weird. Always add the expectations at the
 top level of your test_that.
 
--   Loops
+- Loops
 
 Same goes with for loops:
 
@@ -297,7 +293,7 @@ for (i in names(df)){
 If ever you use this format, `{testthat}` won’t catch the tests, so they
 won’t be reported.
 
--   HTML expectations
+- HTML expectations
 
 As testdown render the text straight in html, if your expecatation
 contains html, it will break the rendering. For example, the following


### PR DESCRIPTION
why :

- testdown detected "expected" as a test

how :

- change the regexp